### PR TITLE
Fix about display of left navigation panel

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -219,7 +219,7 @@
           </li> -->
           <li data-bind="visible: FEATURE_STATS">
               <a href="pages/stats.html">
-                <i class="fa fa-lg fa-fw fa-crosshairs"></i> <span data-bind="locale: 'network_stats'"></span>
+                <i class="fa fa-lg fa-fw fa-crosshairs"></i> <span class="menu-item-parent" data-bind="locale: 'network_stats'"></span>
               </a>
           </li>
         </ul>


### PR DESCRIPTION
Fixed that "Network Stats" label is displayed when folding left panel.